### PR TITLE
Database Timestamp Refactoring for DB Compatibility

### DIFF
--- a/includes/Services/GitContentManager.php
+++ b/includes/Services/GitContentManager.php
@@ -83,7 +83,7 @@ final class GitContentManager {
             wfDebugLog('labkipack', "Registering new repo {$repoUrl}");
             $repoId = $this->repoRegistry->ensureRepoEntry($repoUrl, [
                 'bare_path' => $barePath,
-                'last_fetched' => \wfTimestampNow(),
+                'last_fetched' => $this->repoRegistry->now(),
             ]);
         } else {
             // Repository exists, check if we need to update it
@@ -105,8 +105,8 @@ final class GitContentManager {
                     $this->runGit(['-C', $barePath, 'fetch', '--all', '--tags', '--prune']);
                     // Update the repository entry in the database
                     $this->repoRegistry->updateRepoEntry($repoId, [
-                        'last_fetched' => \wfTimestampNow(),
-                        'updated_at'   => \wfTimestampNow(),
+                        'last_fetched' => $this->repoRegistry->now(),
+                        'updated_at'   => $this->repoRegistry->now(),
                     ]);
                 } catch (\Exception $e) {
                     wfDebugLog('labkipack', "Fetch failed for {$repoUrl}: " . $e->getMessage());
@@ -174,7 +174,7 @@ final class GitContentManager {
         $refId = $this->refRegistry->ensureRefEntry($repoUrl, $ref, [
             'last_commit'   => $commit,
             'worktree_path' => $worktreePath,
-            'updated_at'    => \wfTimestampNow(),
+            'updated_at'    => $this->refRegistry->now(),
             
         ]);
 
@@ -188,7 +188,7 @@ final class GitContentManager {
             'content_ref_name' => $manifest['manifest']['name'],
             'manifest_hash' => $manifest['hash'],
             'manifest_last_parsed' => $manifest['last_parsed_at'],
-            'updated_at'    => \wfTimestampNow(),
+            'updated_at'    => $this->refRegistry->now(),
         ]);
 
         wfDebugLog('labkipack', "Ref {$ref} registered (commit {$commit}, refID={$refId->toInt()}, repoID={$repoUrl})");


### PR DESCRIPTION
## Summary

Refactored database operations to ensure timestamps are stored in the correct DB-specific format, preventing breakage on non-MySQL databases. Implemented pattern with timestamp conversion centralized in registry layer.

## Changes

### 2. Timestamp Conversion Architecture
- Added `*Registry->now()` method to provide DB safe timestamps
- Registry layer handles all DB-specific formatting

## Testing

- Checked DB entries manually but no formal testing 😬... Seems to be working.

## Documentation Reference

Per MediaWiki documentation:
> Never use wfTimestamp() when inserting a timestamp into the database; this will break in PostgreSQL and possibly other non-MySQL databases. Instead use DatabaseBase::timestamp(), aka $dbw->timestamp(), which converts a timestamp in one of the formats accepted by wfTimestamp() to the format used for inserting into timestamp fields in this DBMS.

