### PR TITLE
consolidate registry `now` methods in base class

### DIFF
--- a/includes/Services/BaseRegistry.php
+++ b/includes/Services/BaseRegistry.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LabkiPackManager\Services;
+
+use MediaWiki\MediaWikiServices;
+use Wikimedia\Rdbms\IDatabase;
+
+class BaseRegistry
+{
+    /**
+     * Get current timestamp in DB-specific format.
+     * Can be called by external code to get properly formatted timestamps.
+     * @return string Formatted timestamp for database insertion
+     */
+    public function now(?IDatabase $dbw = null): string {
+        if ($dbw === null){
+            $dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
+        }
+        return $dbw->timestamp( \wfTimestampNow() );
+    }
+}

--- a/includes/Services/LabkiOperationRegistry.php
+++ b/includes/Services/LabkiOperationRegistry.php
@@ -23,7 +23,7 @@ use Wikimedia\Rdbms\IDatabase;
  *
  * @see LabkiRepoAddJob Example usage in background jobs
  */
-final class LabkiOperationRegistry {
+final class LabkiOperationRegistry extends BaseRegistry {
 
     // Re-export Operation constants for backward compatibility
     public const STATUS_QUEUED = Operation::STATUS_QUEUED;
@@ -54,15 +54,6 @@ final class LabkiOperationRegistry {
     }
 
     /**
-     * Get current timestamp in DB-specific format.
-     * Can be called by external code to get properly formatted timestamps.
-     * @return string Formatted timestamp for database insertion
-     */
-    public function now(): string {
-        return $this->dbw->timestamp( wfTimestampNow() );
-    }
-
-    /**
      * Create a new operation record
      *
      * Inserts a new operation into the tracking table. The operation is created with
@@ -88,8 +79,8 @@ final class LabkiOperationRegistry {
             'status' => $status,
             'message' => $message,
             'user_id' => $userId,
-            'created_at' => $this->now(),
-            'updated_at' => $this->now(),
+            'created_at' => $this->now($this->dbw),
+            'updated_at' => $this->now($this->dbw),
         ], __METHOD__ );
     }
 
@@ -115,7 +106,7 @@ final class LabkiOperationRegistry {
     ): void {
         $row = [
             'status' => $status,
-            'updated_at' => $this->now(),
+            'updated_at' => $this->now($this->dbw),
         ];
         if ( $message !== null ) {
             $row['message'] = $message;
@@ -148,8 +139,8 @@ final class LabkiOperationRegistry {
     public function startOperation( OperationId $operationId, ?string $message = null ): void {
         $row = [
             'status' => Operation::STATUS_RUNNING,
-            'started_at' => $this->now(),
-            'updated_at' => $this->now(),
+            'started_at' => $this->now($this->dbw),
+            'updated_at' => $this->now($this->dbw),
         ];
         if ( $message !== null ) {
             $row['message'] = $message;

--- a/includes/Services/LabkiPackRegistry.php
+++ b/includes/Services/LabkiPackRegistry.php
@@ -33,18 +33,8 @@ use Wikimedia\Rdbms\IDatabase;
  *
  * Note: Not marked as final to allow mocking in unit tests.
  */
-class LabkiPackRegistry {
+class LabkiPackRegistry extends BaseRegistry {
     private const TABLE = 'labki_pack';
-
-    /**
-     * Get current timestamp in DB-specific format.
-     * Can be called by external code to get properly formatted timestamps.
-     * @return string Formatted timestamp for database insertion
-     */
-    public function now(): string {
-        $dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
-        return $dbw->timestamp( \wfTimestampNow() );
-    }
 
     /**
      * Insert a pack if not present and return pack_id.

--- a/includes/Services/LabkiPageRegistry.php
+++ b/includes/Services/LabkiPageRegistry.php
@@ -34,18 +34,8 @@ use Wikimedia\Rdbms\IDatabase;
  *
  * Note: Not marked as final to allow mocking in unit tests.
  */
-class LabkiPageRegistry {
+class LabkiPageRegistry extends BaseRegistry {
     private const TABLE = 'labki_page';
-
-    /**
-     * Get current timestamp in DB-specific format.
-     * Can be called by external code to get properly formatted timestamps.
-     * @return string Formatted timestamp for database insertion
-     */
-    public function now(): string {
-        $dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
-        return $dbw->timestamp( \wfTimestampNow() );
-    }
 
     /**
      * Add a page to a pack and return page_id.

--- a/includes/Services/LabkiRefRegistry.php
+++ b/includes/Services/LabkiRefRegistry.php
@@ -36,23 +36,13 @@ use Wikimedia\Rdbms\IDatabase;
  *
  * Note: Not marked as final to allow mocking in unit tests.
  */
-class LabkiRefRegistry {
+class LabkiRefRegistry extends BaseRegistry {
     private const TABLE = 'labki_content_ref';
 
     private LabkiRepoRegistry $repoRegistry;
 
     public function __construct(?LabkiRepoRegistry $repoRegistry = null) {
         $this->repoRegistry = $repoRegistry ?? new LabkiRepoRegistry();
-    }
-
-    /**
-     * Get current timestamp in DB-specific format.
-     * Can be called by external code to get properly formatted timestamps.
-     * @return string Formatted timestamp for database insertion
-     */
-    public function now(): string {
-        $dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
-        return $dbw->timestamp( \wfTimestampNow() );
     }
 
     /**

--- a/includes/Services/LabkiRepoRegistry.php
+++ b/includes/Services/LabkiRepoRegistry.php
@@ -33,18 +33,8 @@ use Wikimedia\Rdbms\IDatabase;
  *
  * Note: Not marked as final to allow mocking in unit tests.
  */
-class LabkiRepoRegistry {
+class LabkiRepoRegistry extends BaseRegistry {
     private const TABLE = 'labki_content_repo';
-
-    /**
-     * Get current timestamp in DB-specific format.
-     * Can be called by external code to get properly formatted timestamps.
-     * @return string Formatted timestamp for database insertion
-     */
-    public function now(): string {
-        $dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
-        return $dbw->timestamp( \wfTimestampNow() );
-    }
 
     /**
      * Ensure a repository entry exists (create or update) and return its ID.


### PR DESCRIPTION
#52 switched to using db timestamps, but duplicated the `now` method across all the registry classes. example of DRY